### PR TITLE
Change access visibility of loadObjModel

### DIFF
--- a/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
+++ b/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
@@ -125,7 +125,7 @@ public class ObjFileImporter implements IModelLoader
 	 *
 	 * @param inputStream the input stream
 	 */
-	private void loadObjModel(InputStream inputStream)
+	protected void loadObjModel(InputStream inputStream)
 	{
 
 		try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream)))


### PR DESCRIPTION
This is a harmless change to the framework that allows someone doing custom loading (such as I do in the Almura mod) to redirect the resource location to files outside assets (as I already do for packs).

I need this change or a load method that takes an InputStream.
