### PR TITLE
Use java 8 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # Source language and JDK version to use
 language: java
-jdk: oraclejdk7
+jdk: oraclejdk8
 
 # Compile and package JAR and set build properties
 install: gradle setupCIWorkspace


### PR DESCRIPTION
Fix builds...

You can close it if you want to hang it there or fix in next commit... Please wait for me to have some time to fix [all compiling errors](https://travis-ci.org/Ordinastie/MalisisCore/builds/80896275#L755) like the use of `ForgeDirection`. 
