### PR TITLE
Fixed ObjFileImporter Spam by adding missing Parser-Types

### DIFF
--- a/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
+++ b/src/main/java/net/malisis/core/renderer/model/loader/ObjFileImporter.java
@@ -178,7 +178,12 @@ public class ObjFileImporter implements IModelLoader
 						case "o":
 							addShape(data);
 							break;
-
+						case "s": 
+							// smoothing group, not supported by backing rendering implementation / ignore.
+							break;
+						case "#":
+							// Skip Comments
+							break;
 						default:
 							MalisisCore.log.debug("[ObjFileImporter] Skipped type {} at line {} : {}", type, lineNumber, currentLine);
 							break;


### PR DESCRIPTION
i've added type 's' (smoothing group, which is just being skipped atm) 
and # .. for comment to the parser

as otherwise the parser would spam the log-file when using the latest release of MalisisDoor's 
with tons of:

```
[11:02:53] [Client thread/DEBUG] [malisiscore/]: [ObjFileImporter] Skipped type # at line 1 : # Blender v2.70 (sub 0) OBJ File: 'saloon_door.blend'
[11:02:53] [Client thread/DEBUG] [malisiscore/]: [ObjFileImporter] Skipped type # at line 2 : # www.blender.org
[11:02:53] [Client thread/DEBUG] [malisiscore/]: [ObjFileImporter] Skipped type s at line 12 : s off
[11:02:53] [Client thread/DEBUG] [malisiscore/]: [ObjFileImporter] Skipped type s at line 106 : s off
```

... :) 
