### PR TITLE
Fix crash in AnimatedRenderer

### DIFF
--- a/src/main/java/net/malisis/core/renderer/AnimatedRenderer.java
+++ b/src/main/java/net/malisis/core/renderer/AnimatedRenderer.java
@@ -58,7 +58,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class AnimatedRenderer extends MalisisRenderer<TileEntity>
 {
 	/** Map of {@link ISortedRenderable} per {@link BlockPos}. */
-	private static Map<BlockPos, IAnimatedRenderable> animatedRenderables = Maps.newHashMap();
+	private static Map<BlockPos, IAnimatedRenderable> animatedRenderables = Maps.newConcurrentMap();
 	static
 	{
 		//check renderable to be removed when a block changes.


### PR DESCRIPTION
This is a workaround because some methods get called from another thread and the client crashes when iterating over the map. Closes #153 